### PR TITLE
Bugfix to update script

### DIFF
--- a/codius-install.sh
+++ b/codius-install.sh
@@ -706,7 +706,7 @@ update()
         local from_version=$( echo $output | cut -d: -f3)
         local to_version=$( echo $output | cut -d: -f2)
         show_message info "[+] Updating ${package} from ${from_version} to ${to_version}... "
-        _exec npm update -g $package unsafe-perm
+        _exec npm update -g $package --unsafe-perm
       else
         show_message info "[+] ${package} already installed latest version."
       fi

--- a/codius-install.sh
+++ b/codius-install.sh
@@ -891,7 +891,7 @@ debug(){
   if [[ $status ]]; then
     validate=( $status )
     if [ ${validate[-2]} == "200" ]; then
-        show_message success "[*] looks likes Codius is running property in your host ."
+        show_message success "[*] looks likes Codius is running properly in your host ."
         new_line
         read -p "Continue Anyway ? [y/N]: " -e CONTINUE
 


### PR DESCRIPTION
Was trying to use the script to update Codiusd to 1.1.1 and it didn’t work. Installed manually with —unsafe-perm and it worked. So I tried to figure out why the script didn’t work and I think it’s because forgot the — part, although I may be completely wrong. If I am sorry about that as I’m not too experienced in this field 😛.

Also a little spelling error from “property” to “properly” in the debug script.