### PR TITLE
Direct users to host's homepage and codiushosts.com

### DIFF
--- a/codius-install.sh
+++ b/codius-install.sh
@@ -657,7 +657,7 @@ server {
   new_line
   show_message done "[!] Congratulations , it's look like Codius installed successfuly!"
   new_line
-  show_message done "[-] You can check your Codius with opening https://$HOSTNAME/version or by visiting the peers list in https://$HOSTNAME/peers "
+  show_message done "[-] You can check your Codius by opening https://$HOSTNAME or by searching for your host at https://codiushosts.com"
   show_message done "[-] For installation log visit $LOG_OUTPUT"
   new_line
   printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' =


### PR DESCRIPTION
With the most recent update of 1.1.3, the index page now takes affect. This page has a bunch of info and links to other endpoints, so would be a better page to direct new hosts too. In addition, I added the message to check their host at codiushosts.com, but that can be removed if you think that's not a good idea.