### PR TITLE
Remove ADDITIONAL_HOST_INFO env var

### DIFF
--- a/codius-install.sh
+++ b/codius-install.sh
@@ -471,7 +471,6 @@ WorkingDirectory=/usr/lib/node_modules/codiusd
 Environment="DEBUG=*"
 Environment="CODIUS_PUBLIC_URI=https://$HOSTNAME"
 Environment="CODIUS_XRP_PER_MONTH=10"
-Environment="CODIUS_ADDITIONAL_HOST_INFO=true"
 Restart=always
 StandardOutput=syslog
 StandardError=syslog


### PR DESCRIPTION
No longer required as of the latest version of codiusd. See PR https://github.com/codius/codiusd/pull/124